### PR TITLE
fix: Use browser type for timer

### DIFF
--- a/src/timeago.ts
+++ b/src/timeago.ts
@@ -23,9 +23,7 @@ export class TimeAgo implements OnInit, OnDestroy{
     transform(val){
        this.timeago = this.getTimeAgo(val)
        if(this.live){
-           this.timer = setInterval(()=> {
-               this.timeago = this.getTimeAgo(val)
-           }, this.interval)
+           this.timer = setInterval(this.timeago = this.getTimeAgo(val), this.interval)
        }
     }
     

--- a/src/timeago.ts
+++ b/src/timeago.ts
@@ -20,10 +20,14 @@ export class TimeAgo implements OnInit, OnDestroy{
     private timeago: string
     private timer: number
     
+    getTimeAgoInterval(val) {
+      this.timeago = this.getTimeAgo(val)
+    }
+
     transform(val){
        this.timeago = this.getTimeAgo(val)
        if(this.live){
-           this.timer = setInterval(this.timeago = this.getTimeAgo(val), this.interval)
+           this.timer = setInterval(() => this.getTimeAgoInterval(val), this.interval)
        }
     }
     


### PR DESCRIPTION
If you want to `timer` as `number` use browser type setInterval (returns `Timeout Id`) not NodeJS.Timer

@xuhong 